### PR TITLE
Send markers to all clients connected

### DIFF
--- a/server/server_random.js
+++ b/server/server_random.js
@@ -33,7 +33,8 @@ io.sockets.on('connection', function (socket) {
     var lat, lng;
     lat = Math.random() * 180 - 90;
     lng = Math.random() * 360 - 180;
-    socket.emit('marker', { lat: lat, lng: lng });
+    socket.emit('marker', { lat: lat, lng: lng
+    socket.broadcast.emit('marker', {lat: lat, lng: lng});
   }
   setInterval(function() { setTimeout(random_point, Math.random() * 1000) }, 500);
 });


### PR DESCRIPTION
If socket.emit is used, the marker is only sent to a single client. If you more than one client connected, it will send different markers sent to each client. Usually you want to broadcast the markers to all clients including the initial requesting client. As the global map should be consistent among clients. 

broadcast.emit broadcasts to everyone except the triggering client. emit is kept for the triggering client.
