### PR TITLE
Channel Configurable, Filter data sent to broswer

### DIFF
--- a/server/config.json.example
+++ b/server/config.json.example
@@ -2,5 +2,6 @@
    "host": "hpfeeds.honeycloud.net",
    "port": 20000,
   "ident": "MyUsername",
-   "auth": "MyPassword"
+   "auth": "MyPassword",
+   "channel": "geoloc.events"
 }


### PR DESCRIPTION
- Made the honeymap server subscription channel configurable
- Filter the fields sent to the browser to only what is needed to render honeymap
